### PR TITLE
Config endpoint url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
 
       - id: flake8
         name: Lint Python (flake8)
-        entry: flake8 --config sfn-workflow-client/.flake8
+        entry: flake8 --config .flake8
         language: python
         types: [file, python]
         additional_dependencies:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To run functional tests, you need to create an AWS IAM role with permissions to:
 
 Set the following environment variables:
 
-- `AWS_ACCOUNT_NUMBER`
+- `AWS_ACCOUNT_ID`
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 - `AWS_DEFAULT_REGION`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# sfn-workflow-client
+# sfn_workflow_client
 
-[![](https://img.shields.io/pypi/v/sfn-workflow-client.svg)](https://pypi.org/pypi/sfn-workflow-client/) [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![](https://img.shields.io/pypi/v/sfn_workflow_client.svg)](https://pypi.org/pypi/sfn_workflow_client/) [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 Enhanced, asyncio-compatible client for AWS Step Functions.
 
@@ -19,10 +19,10 @@ Table of Contents:
 
 ## Installation
 
-sfn-workflow-client requires Python 3.6 or above.
+sfn_workflow_client requires Python 3.6 or above.
 
 ```bash
-pip install sfn-workflow-client
+pip install sfn_workflow_client
 ```
 
 ## Guide
@@ -49,7 +49,7 @@ events = await execution.events.fetch()
 
 ## Development
 
-To develop sfn-workflow-client, install dependencies and enable the pre-commit hook:
+To develop sfn_workflow_client, install dependencies and enable the pre-commit hook:
 
 ```bash
 pip install pre-commit tox

--- a/src/sfn_workflow_client/__init__.py
+++ b/src/sfn_workflow_client/__init__.py
@@ -1,3 +1,3 @@
 """Enhanced, asyncio-compatible client for AWS Step Functions."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/sfn_workflow_client/clients.py
+++ b/src/sfn_workflow_client/clients.py
@@ -1,0 +1,7 @@
+"""Contains shared clients used by the library"""
+
+import boto3
+
+from .config import STEPFUNCTIONS_ENDPOINT_URL
+
+stepfunctions = boto3.client("stepfunctions", endpoint_url=STEPFUNCTIONS_ENDPOINT_URL)

--- a/src/sfn_workflow_client/config.py
+++ b/src/sfn_workflow_client/config.py
@@ -1,4 +1,11 @@
 """Constants and configuration for the workflow client"""
 import os
 
-AWS_ACCOUNT_NUMBER = os.environ.get("AWS_ACCOUNT_NUMBER")
+AWS_ACCOUNT_ID = os.environ.get("AWS_ACCOUNT_ID")
+
+# URL for making requests to the Step Functions API. You would most likely only set
+# this in order to hit the local py2sfn mock server.
+# "The complete URL to use for the constructed client. Normally, botocore will
+# automatically construct the appropriate URL to use when communicating with a service."
+# See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client
+STEPFUNCTIONS_ENDPOINT_URL = os.environ.get("STEPFUNCTIONS_ENDPOINT_URL")

--- a/src/sfn_workflow_client/event.py
+++ b/src/sfn_workflow_client/event.py
@@ -4,15 +4,14 @@ import re
 from typing import Any, Dict, List, Optional
 
 import arrow
-import boto3
 from botocore.exceptions import ClientError
 
+from .clients import stepfunctions
 from .enums import ExecutionEventType
 from .exceptions import ExecutionDoesNotExist
 from .util import call_async, Collection
 
 EVENT_DETAILS_KEY_PATTERN = re.compile(r"EventDetails$")
-stepfunctions = boto3.client("stepfunctions")
 
 
 class ExecutionEvent:

--- a/src/sfn_workflow_client/execution.py
+++ b/src/sfn_workflow_client/execution.py
@@ -6,10 +6,10 @@ import uuid
 
 import arrow
 import backoff
-import boto3
 from botocore.exceptions import ClientError
 
-from .config import AWS_ACCOUNT_NUMBER
+from .clients import stepfunctions
+from .config import AWS_ACCOUNT_ID
 from .enums import COMPLETED_STATUSES, ExecutionStatus
 from .event import ExecutionEventCollection
 from .exceptions import (
@@ -22,7 +22,6 @@ from .exceptions import (
 from .util import call_async, Collection
 
 EVENT_DETAILS_KEY_PATTERN = re.compile(r"EventDetails$")
-stepfunctions = boto3.client("stepfunctions")
 
 
 class Execution:
@@ -70,7 +69,7 @@ class Execution:
     def execution_arn(self) -> str:
         """Returns the execution ARN"""
         return (
-            f"arn:aws:states:{stepfunctions.meta.region_name}:{AWS_ACCOUNT_NUMBER}"
+            f"arn:aws:states:{stepfunctions.meta.region_name}:{AWS_ACCOUNT_ID}"
             f":execution:{self.workflow.name}"
             f":{self.execution_id}"
         )

--- a/src/sfn_workflow_client/workflow.py
+++ b/src/sfn_workflow_client/workflow.py
@@ -1,11 +1,8 @@
 """Contains a client for interacting with a workflow"""
 
-import boto3
-
-from .config import AWS_ACCOUNT_NUMBER
+from .clients import stepfunctions
+from .config import AWS_ACCOUNT_ID
 from .execution import ExecutionCollection
-
-stepfunctions = boto3.client("stepfunctions")
 
 
 class Workflow:
@@ -40,6 +37,6 @@ class Workflow:
         self.name = name
         self.executions = ExecutionCollection([self])
         self.state_machine_arn = (
-            f"arn:aws:states:{stepfunctions.meta.region_name}:{AWS_ACCOUNT_NUMBER}"
+            f"arn:aws:states:{stepfunctions.meta.region_name}:{AWS_ACCOUNT_ID}"
             f":stateMachine:{self.name}"
         )

--- a/tests/functional/test_executions.py
+++ b/tests/functional/test_executions.py
@@ -9,8 +9,8 @@ import unittest
 import uuid
 
 import arrow
-import boto3
 
+from sfn_workflow_client.clients import stepfunctions
 from sfn_workflow_client.enums import ExecutionEventType, ExecutionStatus
 from sfn_workflow_client.exceptions import (
     ExecutionDoesNotExist,
@@ -21,7 +21,6 @@ from sfn_workflow_client.exceptions import (
 from sfn_workflow_client.workflow import Workflow
 from test_utils import async_test
 
-stepfunctions = boto3.client("stepfunctions")
 ROLE_ARN = os.environ["AWS_IAM_ROLE_ARN"]
 
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -15,7 +15,7 @@ class WorkflowUnitTests(unittest.TestCase):
         self.assertEqual(workflow.name, "test")
         self.assertEqual(
             workflow.state_machine_arn,
-            f"arn:aws:states:{os.environ.get('AWS_DEFAULT_REGION')}:{os.environ.get('AWS_ACCOUNT_NUMBER')}:stateMachine:test",
+            f"arn:aws:states:{os.environ.get('AWS_DEFAULT_REGION')}:{os.environ.get('AWS_ACCOUNT_ID')}:stateMachine:test",
         )
         self.assertEqual(len(workflow.executions), 0)
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ isolated_build = True
 deps = pytest
 commands = pytest {posargs}
 passenv =
-    AWS_ACCOUNT_NUMBER
+    AWS_ACCOUNT_ID
     AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY
     AWS_DEFAULT_REGION


### PR DESCRIPTION
@ns-ckao 

- Renames config variable to AWS_ACCOUNT_ID since I see that more commonly
- Adds STEPFUNCTIONS_ENDPOINT_URL configuration variable and consolidated client reference. This will be useful when we need to have this client make requests to a py2sfn local development server instead of AWS.