### PR TITLE
Remove automatic connection to AWS service on import

### DIFF
--- a/src/sfn_workflow_client/__init__.py
+++ b/src/sfn_workflow_client/__init__.py
@@ -1,3 +1,3 @@
 """Enhanced, asyncio-compatible client for AWS Step Functions."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/src/sfn_workflow_client/config.py
+++ b/src/sfn_workflow_client/config.py
@@ -3,9 +3,10 @@ import os
 
 import boto3
 
-AWS_ACCOUNT_ID = os.environ.get(
-    "AWS_ACCOUNT_ID", boto3.client("sts").get_caller_identity()["Account"]
-)
+try:
+    AWS_ACCOUNT_ID = os.environ["AWS_ACCOUNT_ID"]
+except KeyError:
+    AWS_ACCOUNT_ID = boto3.client("sts").get_caller_identity()["Account"]
 
 # URL for making requests to the Step Functions API. You would most likely only set
 # this in order to hit the local py2sfn mock server.


### PR DESCRIPTION
@jdrake 

When using `.get`, the second argument is always evaluated, even if it doesn't get assigned. This means that whenever this module is imported, we will attempt to establish a connection. 

I noticed this when my internet died and I got a connection error trying to run unit tests in some code that had this as a distantly nested dependency somewhere. This change makes it so that if you do have the AWS_ACCOUNT_ID env var set, that doesn't happen.